### PR TITLE
Add .gitignore so that sub-repositories are ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+rpmsg_lite
+erpc


### PR DESCRIPTION
When checking out mcux-sdk with west these two folders exist as nested repositories and should be ignored.